### PR TITLE
Create Header component with react-icons and basic layout

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -11,6 +11,7 @@
         "prop-types": "^15.7.2",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
+        "react-icons": "^5.5.0",
         "react-router-dom": "^7"
       },
       "devDependencies": {
@@ -9810,6 +9811,15 @@
       },
       "peerDependencies": {
         "react": "^19.1.0"
+      }
+    },
+    "node_modules/react-icons": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.5.0.tgz",
+      "integrity": "sha512-MEFcXdkP3dLo8uumGI5xN3lDFNsRtrjbOEKDLD7yv76v4wpnEq2Lt2qeHaQOr34I/wPN3s3+N08WkQ+CW37Xiw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*"
       }
     },
     "node_modules/react-is": {

--- a/client/package.json
+++ b/client/package.json
@@ -23,6 +23,7 @@
     "prop-types": "^15.7.2",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
+    "react-icons": "^5.5.0",
     "react-router-dom": "^7"
   },
   "devDependencies": {

--- a/client/src/components/Header.jsx
+++ b/client/src/components/Header.jsx
@@ -1,0 +1,32 @@
+// Importing icons from Font Awesome library
+import { FaBars, FaBell, FaHeart, FaUserCircle } from "react-icons/fa";
+import  "../styles/HeaderStyle.css";
+import SearchBar from "./SearchBar";
+
+// This component represents the header section of the application
+const Header = ({ searchItem, setSearchItem }) => {
+  return (
+      <div className="header">
+      <div className="left-section">
+        <FaBars className="menu-icon" />
+        <span className="logo">Share with us</span>
+      </div>
+      <div className="search-bar">
+     <SearchBar searchItem={searchItem} setSearchItem={setSearchItem} />
+      </div>
+      <div className="header-right">
+        <FaBell className="header-icon" />
+        <FaHeart className="header-icon" />
+        <FaUserCircle className="header-icon" />
+      </div>
+   </div>
+  );
+};
+
+import PropTypes from "prop-types";
+Header.propTypes = {
+  searchItem: PropTypes.string.isRequired,
+  setSearchItem: PropTypes.func.isRequired,
+};
+
+export default Header;

--- a/client/src/components/Header.jsx
+++ b/client/src/components/Header.jsx
@@ -1,25 +1,25 @@
 // Importing icons from Font Awesome library
 import { FaBars, FaBell, FaHeart, FaUserCircle } from "react-icons/fa";
-import  "../styles/HeaderStyle.css";
+import "../styles/HeaderStyle.css";
 import SearchBar from "./SearchBar";
 
 // This component represents the header section of the application
 const Header = ({ searchItem, setSearchItem }) => {
   return (
-      <div className="header">
+    <div className="header">
       <div className="left-section">
         <FaBars className="menu-icon" />
         <span className="logo">Share with us</span>
       </div>
       <div className="search-bar">
-     <SearchBar searchItem={searchItem} setSearchItem={setSearchItem} />
+        <SearchBar searchItem={searchItem} setSearchItem={setSearchItem} />
       </div>
       <div className="header-right">
         <FaBell className="header-icon" />
         <FaHeart className="header-icon" />
         <FaUserCircle className="header-icon" />
       </div>
-   </div>
+    </div>
   );
 };
 

--- a/client/src/pages/Home/Home.jsx
+++ b/client/src/pages/Home/Home.jsx
@@ -6,7 +6,7 @@ import Header from "../../components/Header";
 
 const Home = () => {
   const [searchItem, setSearchItem] = useState("");
-  
+
   // Temporary mock data for testing UI before backend is ready.
   const items = [
     { id: 1, name: "item1", description: "item1" },

--- a/client/src/pages/Home/Home.jsx
+++ b/client/src/pages/Home/Home.jsx
@@ -1,16 +1,12 @@
 import TEST_ID from "./Home.testid";
-import hyfLogo from "../../assets/hyf-logo.png";
 import { useState } from "react";
-import SearchBar from "../../components/SearchBar";
+// import SearchBar from "../../components/SearchBar";
 import ItemCard from "../../components/ItemCard";
+import Header from "../../components/Header";
 
 const Home = () => {
   const [searchItem, setSearchItem] = useState("");
-  const headerStyle = {
-    background: "navy",
-    color: "snow",
-    padding: "1rem",
-  };
+  
   // Temporary mock data for testing UI before backend is ready.
   const items = [
     { id: 1, name: "item1", description: "item1" },
@@ -29,10 +25,7 @@ const Home = () => {
   );
   return (
     <div data-testid={TEST_ID.container}>
-      <h1 style={headerStyle}>This is the homepage</h1>
-      <p>Good luck with the project!</p>
-      <img src={hyfLogo} alt="HackYourFuture Logo" style={{ width: "200px" }} />
-      <SearchBar searchItem={searchItem} setSearchItem={setSearchItem} />
+      <Header searchItem={searchItem} setSearchItem={setSearchItem} />
       <div style={{ display: "flex", flexDirection: "column", gap: "1rem" }}>
         {filteredItems.length > 0 ? (
           filteredItems.map((item) => <ItemCard key={item.id} item={item} />)

--- a/client/src/styles/HeaderStyle.css
+++ b/client/src/styles/HeaderStyle.css
@@ -21,7 +21,7 @@
 }
 
 .logo {
-  padding:4px;
+  padding: 4px;
   font-size: 18px;
   font-weight: bold;
   color: #4b0cdf;

--- a/client/src/styles/HeaderStyle.css
+++ b/client/src/styles/HeaderStyle.css
@@ -7,7 +7,6 @@
   color: rgb(104, 102, 102);
   padding: 1rem;
   border-radius: 10px;
-  padding: 10px 20px;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
   position: relative;
 }

--- a/client/src/styles/HeaderStyle.css
+++ b/client/src/styles/HeaderStyle.css
@@ -1,0 +1,34 @@
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  height: 50px;
+  background-color: #d4d5d6;
+  color: rgb(104, 102, 102);
+  padding: 1rem;
+  border-radius: 10px;
+  padding: 10px 20px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  position: relative;
+}
+
+.menu-icon {
+  background: none;
+  border: none;
+  font-size: 24px;
+  color: rgb(104, 102, 102);
+  cursor: pointer;
+}
+
+.logo {
+  padding:4px;
+  font-size: 18px;
+  font-weight: bold;
+  color: #4b0cdf;
+  margin-left: 4rem;
+}
+
+.header-right .header-icon {
+  margin-left: 1rem;
+  cursor: pointer;
+}


### PR DESCRIPTION

 What I did:
- Created a `Header` component to match the design in Miro.
- Added three sections: left (menu icon), center (title), and right (icons).
- Used `react-icons` library to import `FaBars`, `FaBell`, `FaHeart`, and `FaUserCircle`.
- Moved the `SearchBar` component into the header and aligned it to the center.

 **Notes:**
- `react-icons` has been added to `package.json`.
Please review and let me know if any changes are needed.
