### PR TITLE
Pagination support for the result page

### DIFF
--- a/server/src/controllers/item.js
+++ b/server/src/controllers/item.js
@@ -3,8 +3,8 @@ import { logError } from "../util/logging.js";
 
 export const getItems = async (req, res) => {
   try {
-    const limit = req.query?.limit || 10;
-    const page = req.query?.page || 1;
+    const limit = parseInt(req.query?.limit) || 10;
+    const page = parseInt(req.query?.page) || 1;
     const offset = (page - 1) * limit;
 
     const items = await Item.find()

--- a/server/src/controllers/item.js
+++ b/server/src/controllers/item.js
@@ -3,7 +3,15 @@ import { logError } from "../util/logging.js";
 
 export const getItems = async (req, res) => {
   try {
-    const items = await Item.find();
+    const limit = req.query?.limit || 10;
+    const page = req.query?.page || 1;
+    const offset = (page - 1) * limit;
+
+    const items = await Item.find()
+      .sort({ createdAt: -1 })
+      .limit(limit)
+      .skip(offset);
+
     res.status(200).json({ success: true, result: items });
   } catch (error) {
     logError(error);


### PR DESCRIPTION
This PR adds backend support for item list pagination.

- Same endpoint as getting a list of all items.
- Uses query strings set the current page and the number of items.
- Sorts by creation time (default is newest to oldest).
- Defaults to 10 items per page and starts from 1st page if the request has no query strings.
- Example usage `/api/items?&page=1&limit=5`.

![image](https://github.com/user-attachments/assets/df2a3605-8f4b-47c8-94b2-9f1b7e546db0)
![image](https://github.com/user-attachments/assets/5e420941-56b0-4ada-80d9-83b66f25988a)
